### PR TITLE
[fix] Fit composer requirement

### DIFF
--- a/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/ArrayCollectionTest.php
@@ -346,13 +346,17 @@ class ArrayCollectionTest extends \PHPUnit_Framework_TestCase
             )
         );
 
+        /**
+         * @param \DateTimeInterface $date
+         * @return bool
+         */
+        $predicate = function ($date) use ($dateTime) {
+            return $date->format('Y-m-d') === $dateTime->format('Y-m-d');
+        };
         $criteria = Criteria::create()
             ->andWhere(
-                Criteria::expr()->matchingClosure(function(\DateTimeInterface $date) use ($dateTime) {
-                    return $date->format('Y-m-d') === $dateTime->format('Y-m-d');
-                })
-            )
-        ;
+                Criteria::expr()->matchingClosure($predicate)
+            );
         $this->assertCount(2, $collection->matching($criteria));
     }
 }


### PR DESCRIPTION
As of [composer requirement]() minimal supported PHP version is PHP 5.3 - this is why [build](https://travis-ci.org/doctrine/collections/builds/177511823) fails.

And as [documentation](http://php.net/manual/en/class.datetimeinterface.php) says: `\DateTimeInterface` was introduced at PHP 5.5

Hope it can help to merge [pull request](https://github.com/doctrine/collections/pull/96) faster.